### PR TITLE
Refactoring fetch_all_attendees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ serde_derive = "1.0"
 # Http client
 reqwest = "0.9.5"
 # Utils
-frunk = "0.2.1"
 rand = "0.5.5"
 matches = "0.1.8"
 # Actor

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ extern crate failure_derive;
 extern crate serde_derive;
 extern crate serde;
 extern crate reqwest;
-extern crate frunk;
 extern crate rand;
 extern crate core;
 


### PR DESCRIPTION
When I saw your talk about Rust on Youtube https://www.youtube.com/watch?v=j_4sadjjWh8 (great talk), I was intrigued by the way you handled the pagination.
so I looked into the code to see if I could improve it.

- Range has been replaced by `(start..end)`
- `sequence` has been replaced by https://doc.rust-lang.org/std/iter/trait.FromIterator.html#method.from_iter-14
- `combine_all` has been replaced by `flat_map`

It compiles but I have not tested the code.

I know the code is old but who knows if you still use it